### PR TITLE
Update actions & add dependabot for action-updates via PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -7,18 +7,20 @@ on:
   pull_request:
     branches: [main]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   codespell:
     name: Check for spelling errors
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630
         with:
           skip: '*.js'

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The following are required and recommended tools for using this copier template 
   To execute these commands you need [just](https://github.com/casey/just) as command runner. Install it by running:
 
   ```shell
-  pipx install just
+  pipx install rust-just
   ```
 
 ## Creating a new project

--- a/copier.yaml
+++ b/copier.yaml
@@ -12,7 +12,7 @@ project_name:
 
 project_slug:
     type: str
-    help: A slug of the name. Must be a valid Python package name.
+    help: A slug of the name. Must be a valid and unused Python package name.
     default: "{% from pathjoin('includes', 'slugify.jinja') import slugify %}{{ slugify(project_name) }}"
     # regex_search is part of a jinja extension loaded by default.
     # It is case insensitive by default. We need to set ignorecase=False to make it case sensitive.

--- a/template/.github/dependabot.yml
+++ b/template/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly

--- a/template/.github/workflows/deploy-docs.yaml.jinja
+++ b/template/.github/workflows/deploy-docs.yaml.jinja
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+
+permissions: {}
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest
@@ -16,12 +19,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
+          persist-credentials: false
 
       - name: Set up Python.
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
           python-version: 3.9
 

--- a/template/.github/workflows/main.yaml.jinja
+++ b/template/.github/workflows/main.yaml.jinja
@@ -30,7 +30,7 @@ jobs:
       - name: Install Poetry
         run: |
           pipx install poetry
-          pipx install just
+          pipx install rust-just
 
       # We install poetry-dynamic-versioning into pipx because the automatic installallation
       # by poetry 2.x triggers a Windows issue https://github.com/pypa/installer/issues/260

--- a/template/.github/workflows/main.yaml.jinja
+++ b/template/.github/workflows/main.yaml.jinja
@@ -5,26 +5,39 @@ name: Build and test {{project_slug}}
 
 on: [pull_request]
 
+permissions: {}
+
 jobs:
   test:
 
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
 
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
           python-version: ${{ "{{" }} matrix.python-version {{ "}}" }}
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: |
+          pipx install poetry
+          pipx install just
+
+      # We install poetry-dynamic-versioning into pipx because the automatic installallation
+      # by poetry 2.x triggers a Windows issue https://github.com/pypa/installer/issues/260
+      - name: Install poetry-dynamic-versioning
+        if: runner.os == 'Windows'
+        run:
+          pipx inject poetry poetry-dynamic-versioning
 
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
@@ -33,4 +46,4 @@ jobs:
         run: poetry install --no-interaction
 
       - name: Run test suite
-        run: make test
+        run: just test

--- a/template/.github/workflows/pypi-publish.yaml.jinja
+++ b/template/.github/workflows/pypi-publish.yaml.jinja
@@ -1,36 +1,86 @@
 ---
 name: Publish Python Package
 
+# Publishes with trusted publishing to
+# - PyPI on releases created in GitHub UI if status is published.
+#   For draft status, nothing happens.
+# - TestPyPI on new tags "v1.2.3" or "v1.2.3.something" on main branch
+#
+# More on trusted publishing: https://docs.pypi.org/trusted-publishers/
+
 on:
+  push:
+    tags:
+      # GitHub glob matching is limited [1]. So we can't define a pattern matching
+      # pep 440 version definition [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
+      - 'v[0-9]+.[0-9]+.[0-9]+.?*'
   release:
-    types: [created]
+    types: [published]
+
+permissions: {}
 
 jobs:
-  build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI
+  build:
+    name: Build Python 🐍 distributions 📦 for publishing
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
           python-version: 3.9
 
       - name: Install Poetry
         run: |
           pipx install poetry
-          poetry self add "poetry-dynamic-versioning[plugin]"
-
-      # - name: Install dependencies
-      #   run: poetry install --no-interaction
 
       - name: Build source and wheel archives
         run: poetry build
 
-      - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.2.2
+      - name: Store built distribution
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b
         with:
-          user: __token__
-          password: ${{ "{{" }} secrets.{{github_token_for_pypi_deployment}} {{ "}}" }}
+          name: distribution-files
+          path: dist/
+
+  pypi-publish:
+    name: Build and publish Python 🐍 package 📦 to PyPI and TestPyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi-release
+      url: https://pypi.org/p/{{ project_slug }}
+    permissions:
+      id-token: write  # this permission is mandatory for trusted publishing
+    steps:
+      - name: Download built distribution
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16
+        with:
+          name: distribution-files
+          path: dist
+
+      - name: Publish package 📦 to Test PyPI
+        if: github.event_name == 'push'
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          verbose: true
+
+      - name: Publish package 📦 to PyPI
+        if: github.event_name == 'release'
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        with:
+          verbose: true
+
+# [1] https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+# Used actions: (updates managed by dependabot)
+# - https://github.com/actions/checkout
+# - https://github.com/actions/setup-python
+# - https://github.com/actions/upload-artifact
+# - https://github.com/actions/download-artifact
+# - https://github.com/pypa/gh-action-pypi-publish/

--- a/template/.github/workflows/test_pages_build.yaml.jinja
+++ b/template/.github/workflows/test_pages_build.yaml.jinja
@@ -29,7 +29,7 @@ jobs:
       - name: Install Poetry
         run: |
           pipx install poetry
-          pipx install just
+          pipx install rust-just
 
       - name: Install dependencies
         run: poetry install -E docs

--- a/template/.github/workflows/test_pages_build.yaml.jinja
+++ b/template/.github/workflows/test_pages_build.yaml.jinja
@@ -9,22 +9,27 @@ on:
 
 concurrency: {% raw %}preview-${{ github.ref }}{% endraw %}
 
+permissions: {}
+
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python 3
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
           python-version: 3.9
 
       - name: Install Poetry
-        run: pipx install poetry
+        run: |
+          pipx install poetry
+          pipx install just
 
       - name: Install dependencies
         run: poetry install -E docs
@@ -33,12 +38,12 @@ jobs:
         run: |
           mkdir -p site
           touch site/.nojekyll
-          make gendoc
+          just gendoc
           ([ ! -f docs/about.md ] && cp src/docs/about.md docs/) || true
           poetry run mkdocs build -d site
 
       - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@df22037db54ab6ee34d3c1e2b8810ac040a530c6
         with:
           source-dir: site/
           preview-branch: gh-pages


### PR DESCRIPTION
- [x] Update workflows to use hash-specifier for actions
- [x] Review actions for security issues; the changes make them pass the check with zizmor 1.3.0 with option `--pedantic`.
- [x] Use [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) for python-package
- [x] Add dependabot auto-update for actions

Closes #6