### PR TITLE
Add note on Poetry version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ The following are required and recommended tools for using this copier template 
   pipx install poetry
   ```
 
+  This will install Poetry 2.0 as required by this project.
+  If you also need Poetry 1.x for other projects, you can have both Poetry 2.x and Poetry 1.x installed at the same time.
+  pipx has the option to install another version with a suffix-modified name, here "poetry1",
+
+    ```bash
+      `pipx install --suffix=1 "poetry<2.0"`.
+    ```
+
 * **Poetry Dynamic Versioning Plugin**:
 
   This plugin automatically updates certain version strings in your generated project when you publish it. Your generated project will automatically be set up to use it. Install it by running:


### PR DESCRIPTION
The template requires Poetry 2.0. We should make that clear since Poetry 2.0 just came out in Jan 2025.