### PR TITLE
Update action and config files based on test-migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,5 +128,7 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# pycharm
 .idea
+# Local vscode editor config
 .vscode

--- a/template/.github/workflows/deploy-docs.yaml.jinja
+++ b/template/.github/workflows/deploy-docs.yaml.jinja
@@ -3,7 +3,7 @@ name: Auto-deployment of {{project_name}} documentation
 on:
   push:
     branches: [main]
-
+  workflow_dispatch:
 
 permissions: {}
 
@@ -24,18 +24,23 @@ jobs:
           fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
           persist-credentials: false
 
-      - name: Set up Python.
+      - name: Set up Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
-          python-version: 3.9
+          python-version: 3.12
 
-      - name: Install Poetry.
-        run: pipx install poetry
+      - name: Install Poetry incl. plugins
+        # We install poetry-dynamic-versioning into pipx because the automatic installallation
+        # by poetry 2.x triggers a Windows issue https://github.com/pypa/installer/issues/260
+        # and also does not work on Ubuntu in gh-actions.        
+        run: |
+          pipx install poetry
+          pipx inject poetry poetry-dynamic-versioning
 
-      - name: Install dependencies.
+      - name: Install dependencies
         run: poetry install -E docs
 
-      - name: Build documentation.
+      - name: Build documentation
         run: |
           mkdir -p docs
           touch docs/.nojekyll

--- a/template/.github/workflows/main.yaml.jinja
+++ b/template/.github/workflows/main.yaml.jinja
@@ -22,21 +22,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python
+      - name: Set up Python {{ matrix.python-version }}
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
           python-version: ${{ "{{" }} matrix.python-version {{ "}}" }}
 
-      - name: Install Poetry
+      - name: Install just & Poetry incl. plugins
+        # We install poetry-dynamic-versioning into pipx because the automatic installallation
+        # by poetry 2.x triggers a Windows issue https://github.com/pypa/installer/issues/260
+        # and also does not work on Ubuntu in gh-actions.        
         run: |
-          pipx install poetry
           pipx install rust-just
-
-      # We install poetry-dynamic-versioning into pipx because the automatic installallation
-      # by poetry 2.x triggers a Windows issue https://github.com/pypa/installer/issues/260
-      - name: Install poetry-dynamic-versioning
-        if: runner.os == 'Windows'
-        run:
+          pipx install poetry
           pipx inject poetry poetry-dynamic-versioning
 
       - name: Install dependencies

--- a/template/.github/workflows/pypi-publish.yaml.jinja
+++ b/template/.github/workflows/pypi-publish.yaml.jinja
@@ -35,9 +35,14 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Install Poetry
+      - name: Install just & Poetry incl. plugins
+        # We install poetry-dynamic-versioning into pipx because the automatic installallation
+        # by poetry 2.x triggers a Windows issue https://github.com/pypa/installer/issues/260
+        # and also does not work on Ubuntu in gh-actions.        
         run: |
+          pipx install rust-just
           pipx install poetry
+          pipx inject poetry poetry-dynamic-versioning
 
       - name: Build source and wheel archives
         run: poetry build

--- a/template/.github/workflows/test_pages_build.yaml.jinja
+++ b/template/.github/workflows/test_pages_build.yaml.jinja
@@ -26,10 +26,14 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Install Poetry
+      - name: Install just & Poetry incl. plugins
+        # We install poetry-dynamic-versioning into pipx because the automatic installallation
+        # by poetry 2.x triggers a Windows issue https://github.com/pypa/installer/issues/260
+        # and also does not work on Ubuntu in gh-actions.        
         run: |
-          pipx install poetry
           pipx install rust-just
+          pipx install poetry
+          pipx inject poetry poetry-dynamic-versioning
 
       - name: Install dependencies
         run: poetry install -E docs

--- a/template/mkdocs.yml.jinja
+++ b/template/mkdocs.yml.jinja
@@ -12,7 +12,7 @@ plugins:
   - mknotebooks:
       execute: false
   - mermaid2:
-      version: 10.9.0
+      version: 11.4.1
 nav:
   # - Home: home.md
   - Index: index.md

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -12,7 +12,8 @@ license = {text = "{{license}}"}
 readme = "README.md"
 include = ["README.md", "src/{{project_slug}}/schema", "project"]
 
-requires-python = ">=3.9"
+# We can't use caret ^ requirement specifiers here. They are a Poetry speciality.
+requires-python = ">=3.11,<4.0"
 
 dynamic = ["version"]
 
@@ -29,7 +30,7 @@ python = "^3.9"
 linkml-runtime = "^1.1.24"
 
 [tool.poetry.requires-plugins]
-poetry-dynamic-versioning = ">=1.5.2"
+poetry-dynamic-versioning = ">=1.7.0"
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
This fixes small issues that a test-migration of pid4cat-model revealed.

- inject poetry-dynamic-versioning in gh-action workflows (only way that works reliably, as learned in linkml/linkml-runtime#364) 
- update/fix versions constraints in pyproject.toml
