### PR TITLE
Fix clean command to not remove README and __init__.py

### DIFF
--- a/template/justfile
+++ b/template/justfile
@@ -176,13 +176,29 @@ _git-commit:
 _git-status:
     git status
 
+_clean_project:
+    #!{{shebang}}
+    import shutil, pathlib
+    # remove the generated project files
+    for d in pathlib.Path("{{dest}}").iterdir():
+        if d.is_dir():
+            print(f'removing "{d}"')
+            shutil.rmtree(d, ignore_errors=True)
+    # remove the generated python data model
+    for d in pathlib.Path("{{pymodel}}").iterdir():
+        if str(d) == "__init__.py":
+            continue
+        print(f'removing "{d}"')
+        if d.is_dir():
+            shutil.rmtree(d, ignore_errors=True)
+        else:
+            d.unlink()
+
 # Clean all generated files
 [group('project management')]
-clean:
-    rm -rf {{dest}}
+clean: _clean_project
     rm -rf tmp
     rm -rf {{docdir}}/*
-    rm -rf {{pymodel}}
 
 # Private recipes
 _ensure_pymodel_dir:


### PR DESCRIPTION
Fixes the too brutal directory clean-up from [linkml_project_cookiecutter](https://github.com/linkml/linkml-project-cookiecutter/issues/132).

This only fixes the `just clean` command but not `make clean` (since we'll remove make support #2).

We use Python to selectively delete in the folders. Using the Python in this case was easier than finding a shell script solution that works everywhere.