### PR TITLE
Fix poetry install cmd in doc-building actions

### DIFF
--- a/template/.github/workflows/deploy-docs.yaml.jinja
+++ b/template/.github/workflows/deploy-docs.yaml.jinja
@@ -38,7 +38,7 @@ jobs:
           pipx inject poetry poetry-dynamic-versioning
 
       - name: Install dependencies
-        run: poetry install -E docs
+        run: poetry install docs
 
       - name: Build documentation
         run: |

--- a/template/.github/workflows/test_pages_build.yaml.jinja
+++ b/template/.github/workflows/test_pages_build.yaml.jinja
@@ -36,7 +36,7 @@ jobs:
           pipx inject poetry poetry-dynamic-versioning
 
       - name: Install dependencies
-        run: poetry install -E docs
+        run: poetry install docs
 
       - name: Build documentation
         run: |


### PR DESCRIPTION
The mkdocs-related packages we do not specify as "extras" but as development dependencies. However, the install command was referring to extras and thus failed.