### PR TITLE
Give gh-pages bot a name/email for a better git log

### DIFF
--- a/template/.github/workflows/deploy-docs.yaml
+++ b/template/.github/workflows/deploy-docs.yaml
@@ -23,6 +23,13 @@ jobs:
         with:
           fetch-depth: 0  # otherwise, you will failed to push refs to dest repo
 
+      - name: Configure git for the bot
+        # Gives the bot that commits to gh-pages a name & email address
+        # so that the commits have an author in the commit log.
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email github-actions[bot]@users.noreply.github.com
+
       - name: Set up Python
         uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
         with:


### PR DESCRIPTION
The action runs without this, but this improves the information in git commit log. Without this the commits have no author.