### PR TITLE
Remove redundant dependency spec

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -25,10 +25,6 @@ dependencies = [
 requires-poetry = ">=2.0"
 version = "0.0.0"
 
-[tool.poetry.dependencies]
-python = "^3.9"
-linkml-runtime = "^1.1.24"
-
 [tool.poetry.requires-plugins]
 poetry-dynamic-versioning = ">=1.7.0"
 


### PR DESCRIPTION
Python and linkml-runtime was specified at two places.

It worked nonetheless and `poetry check` didn't complain so it was not noticed before.