### PR TITLE
Use exact link to schema index in root index

### DIFF
--- a/template/docs/index.md.jinja
+++ b/template/docs/index.md.jinja
@@ -2,4 +2,4 @@
 
 {{project_description}}
 
-- Auto-generated [schema documentation](./elements/)
+- Auto-generated [schema documentation](elements/index.md)


### PR DESCRIPTION
Minor change to avoid warning during mkdocs build.