### PR TITLE
Fix migration from 0.1.x to 0.2.x by Python script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 - Improved 0.2.x-migration message for `just update`.
 
+### Fixed
+
+- Moving files in the 0.2.0-migration was incomplete and gave errors due to non-existing folders.
+  The just recipe was replaced by a new Python recipe to work around the limitations of `git mv`.
+
 ## Release [0.2.1] - 2025-02-16
 
 [Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.2.1...v0.2.0)

--- a/template/docs/templates-linkml/README.md
+++ b/template/docs/templates-linkml/README.md
@@ -1,3 +1,7 @@
-Use this folder to store templates to modify the generated documentation. The templates are written in Jinja2 and are used to generate the HTML documentation for the schema.
+# Templates for the LinkML documentation generator
 
-The default templates are stored in the linkml repository at https://github.com/linkml/linkml/tree/main/linkml/generators/docgen. If you want to use these as a starting point, you can copy them into this folder and modify them as needed.
+Use this folder to store templates to customize the generated model documentation.
+The templates are written in Jinja2 and are used to generate the HTML documentation for the schema.
+
+The default templates are available in the [linkml repository](https://github.com/linkml/linkml/tree/main/linkml/generators/docgen).
+If you want to use these as a starting point, you can copy them into this folder and modify them as needed.

--- a/template/justfile
+++ b/template/justfile
@@ -113,11 +113,27 @@ gen-project:
 # created with linkml-project-copier v0.1.x to v0.2.0 or newer.
 # Use with care! - It may not work for customized projects.
 _post_upgrade_v020:
-    -mv docs/*.md docs/elements
-    -git mv src/docs/files docs
-    -git mv src/docs/templates docs/templates-linkml
-    -git mv src/data/examples tests/data/
-    echo "Migration to v0.2.x completed! Check the changes carefully before committing them."
+    #!{{shebang}}
+    import subprocess
+    from pathlib import Path
+    # Git move files from folder src to folder dest
+    tasks = [
+        (Path("src/docs/files"), Path("docs")),
+        (Path("src/docs/templates"), Path("docs/templates-linkml")),
+        (Path("src/data/examples"), Path("tests/data/")),
+    ]
+    for src, dest in tasks:
+        for path_obj in src.rglob("*"):
+            if not path_obj.is_file():
+                continue
+            file_dest = dest / path_obj.relative_to(src)
+            if not file_dest.parent.exists():
+                file_dest.parent.mkdir(parents=True)
+            print(f"Moving {path_obj} --> {file_dest}")
+            subprocess.run(["git", "mv", str(path_obj), str(file_dest)])
+    print(
+        "Migration to v0.2.x completed! Check the changes carefully before committing."
+    )
 
 # ============== Hidden internal recipes ==============
 


### PR DESCRIPTION
- Moving files in the 0.2.0-migration was incomplete and gave errors due to non-existing folders.
  The just recipe was replaced by a new Python recipe to work around the limitations of `git mv`.