### PR TITLE
Add typos to pre-commit in repo and project

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,8 @@ repos:
     rev: v2.4.1
     hooks:
       - id: codespell
+
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.29.7
+    hooks:
+      - id: typos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 [Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.2.2...main)
 
+### Added
+
+- Typos integration with pre-commit (was only an gh-action before)
+
 ## Release [0.2.2] - 2025-02-17
 
 [Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.2.2...v0.2.1)

--- a/template/.github/workflows/{% if gh_action_pypi %}pypi-publish.yaml{% endif %}.jinja
+++ b/template/.github/workflows/{% if gh_action_pypi %}pypi-publish.yaml{% endif %}.jinja
@@ -1,8 +1,6 @@
 ---
 name: Publish Python Package
 
-# Publishes with trusted publishing toPublishes with trusted publishing toPublishes with trusted publishing toPublishes with trusted publishing toPublishes with trusted publishing to
-
 # Publishes with trusted publishing to
 # - PyPI on releases created in GitHub UI if status is published.
 #   For draft status, nothing happens.

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -23,6 +23,11 @@ repos:
         additional_dependencies:
           - tomli
 
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.29.7
+    hooks:
+      - id: typos
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.9.6


### PR DESCRIPTION
The [typos](https://github.com/crate-ci/typos) spell checker was only used in gh-actions of the repo but it should be possible to detect the errors before committing with the help of [pre-commit](https://[pre-commit](https://pre-commit.com/).com/).