### PR TITLE
Ignore folder with generated part of docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,11 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Fixed
 
-- Fix yamllint config-location in pre-commit configuration of the project. #59
+- Fix yamllint config-location in pre-commit configuration of the project. #60
 
 ### Changed
 
-- The generated part of the documentation is now git-ignored (`docs/elements/*.md`). #60
+- The generated part of the documentation is now git-ignored (`docs/elements/*.md`). #59
 
 ## Release [0.2.2] - 2025-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 - Typos integration with pre-commit (was only an gh-action before). #58
 
+### Fixed
+
+- Fix yamllint config-location in pre-commit configuration of the project. #59
+
+### Changed
+
+- The generated part of the documentation is now git-ignored (`docs/elements/*.md`). #60
+
 ## Release [0.2.2] - 2025-02-17
 
 [Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.2.2...v0.2.1)

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,6 +1,9 @@
-/tmp/
+# generated part of documentation
+/docs/elements/*.md
 # linkml-run-examples output (not useful to have in git in its current form)
 /examples/output/
+
+/tmp/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/template/examples/README.md.jinja
+++ b/template/examples/README.md.jinja
@@ -1,4 +1,4 @@
-# Examples of using {{project_slug}}
+# Examples of using {{project_name}}
 
 This folder contains examples using the datamodel.
 

--- a/template/justfile
+++ b/template/justfile
@@ -112,7 +112,10 @@ gen-project:
 # Hidden command to adjust the directory layout on upgrading a project
 # created with linkml-project-copier v0.1.x to v0.2.0 or newer.
 # Use with care! - It may not work for customized projects.
-_post_upgrade_v020:
+_post_upgrade_v020: && _post_upgrade_v020py
+    mv docs/*.md docs/elements
+
+_post_upgrade_v020py:
     #!{{shebang}}
     import subprocess
     from pathlib import Path


### PR DESCRIPTION
- The generated part of the documentation is now git-ignored (`docs/elements/*.md`).