### PR TITLE
Fix docs build in gh-actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 ### Fixed
 
 - Fix yamllint config-location in pre-commit configuration of the project. #60
+- Generate markdown schema documentation as part of docs build in gh-actions.
 
 ### Changed
 
 - The generated part of the documentation is now git-ignored (`docs/elements/*.md`). #59
+- Make gen-doc a visible just command (was already present as "_gendoc").
 
 ## Release [0.2.2] - 2025-02-17
 

--- a/template/.github/workflows/deploy-docs.yaml
+++ b/template/.github/workflows/deploy-docs.yaml
@@ -35,7 +35,7 @@ jobs:
         with:
           python-version: 3.12
 
-      - name: Install poetry incl. plugins
+      - name: Install poetry incl. plugins and just
         # We install poetry-dynamic-versioning into pipx because the automatic
         # install by poetry 2.x triggers a Windows issue
         # https://github.com/pypa/installer/issues/260
@@ -43,10 +43,12 @@ jobs:
         run: |
           pipx install poetry
           pipx inject poetry poetry-dynamic-versioning
+          pipx install rust-just
 
       - name: Install dependencies
         run: poetry install
 
       - name: Build and deploy documentation
         run: |
+          just gen-doc
           poetry run mkdocs gh-deploy

--- a/template/justfile
+++ b/template/justfile
@@ -49,7 +49,7 @@ _default: _status
 setup: _check-config _git-init install _git-add && _setup_part2
   git commit -m "Initialise git with minimal project" -a
 
-_setup_part2: gen-project _gendoc
+_setup_part2: gen-project gen-doc
   git add .
   git commit -m "Add generated docs and project artefacts" -a
 
@@ -70,7 +70,7 @@ clean: _clean_project
 
 # (Re-)Generate project and documentation locally
 [group('model development')]
-site: gen-project _gendoc
+site: gen-project gen-doc
 
 # Deploy documentation site to Github Pages
 [group('deployment')]
@@ -86,9 +86,14 @@ test: _test-schema _test-python _test-examples
 lint:
     poetry run linkml-lint {{source_schema_path}}
 
+# Generate md documentation for the schema
+[group('model development')]
+gen-doc:
+    poetry run gen-doc {{gen_doc_args}} -d {{docdir}} {{source_schema_path}}
+
 # Build docs and run test server
 [group('model development')]
-testdoc: _gendoc _serve
+testdoc: gen-doc _serve
 
 # Generate project files including Python data model
 [group('model development')]
@@ -180,10 +185,6 @@ _test-examples: _ensure_examples_output
         --input-directory tests/data/valid \
         --output-directory examples/output \
         --schema {{source_schema_path}} > examples/output/README.md
-
-# Generate documentation for the schema
-_gendoc:
-    poetry run gen-doc {{gen_doc_args}} -d {{docdir}} {{source_schema_path}}
 
 # Run documentation server
 _serve:

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -45,7 +45,7 @@ mknotebooks = ">= 0.8.0"
 
 # Ref.: https://github.com/codespell-project/codespell
 [tool.codespell]
-skip = "pyproject.toml,LICENSE"
+skip = "LICENSE,poetry.lock,pyproject.toml"
 
 # Reminder: words have to be lowercased for the ignore-words-list
 ignore-words-list = "linke"
@@ -57,5 +57,6 @@ linke = "linke"
 [tool.typos.files]
 extend-exclude = [
   "LICENSE",
+  "poetry.lock",
   "pyproject.toml",
 ]


### PR DESCRIPTION
- Generate markdown schema documentation as part of docs build in gh-actions.
- Make `gen-doc` a visible just command (was already present as `_gendoc`).