### PR TITLE
Fix clean cmd to remove only md-files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 - Fix yamllint config-location in pre-commit configuration of the project. #60
 - Generate markdown schema documentation as part of docs build in gh-actions.
+- Fix clean command to remove only md-files from `docs/elements`
 
 ### Changed
 

--- a/template/justfile
+++ b/template/justfile
@@ -66,7 +66,7 @@ update: _update-template _update-linkml
 [group('project management')]
 clean: _clean_project
     rm -rf tmp
-    rm -rf {{docdir}}/*
+    rm -rf {{docdir}}/*.md
 
 # (Re-)Generate project and documentation locally
 [group('model development')]


### PR DESCRIPTION
`just clean` removes all files from `docs/elements` folder. The removal of `.gitkeep` file could lead to the undesired removal of this folder.

This PR limits cleaning to removal of markdown (md) files.