### PR TITLE
Fix / improve just recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,13 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 -->
 ## Unreleased
 
-[Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.2.2...main)
+[Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.3.0...main)
+
+## Release [0.3.0] - 2025-03-02
+
+[Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.2.2...0.3.0)
+
+[0.3.0]: https://github.com/dalito/linkml-project-copier/releases/tag/v0.3.0
 
 ### Added
 
@@ -25,12 +31,24 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 - Fix yamllint config-location in pre-commit configuration of the project. #60
 - Generate markdown schema documentation as part of docs build in gh-actions.
-- Fix clean command to remove only md-files from `docs/elements`
+- Remove old files from `docs/elemnents" before re-creating markdown files. #66
+- Fix clean command to remove only md-files from `docs/elements`.
+- Generate java code from model. #70
+- Clean `examples/output` folder before re-creating its content in recipe `just test`. #72
 
 ### Changed
 
 - The generated part of the documentation is now git-ignored (`docs/elements/*.md`). #59
 - Make gen-doc a visible just command (was already present as "_gendoc").
+- Don't commit project artifacts on initialisation. #65
+- Let `just lint` recipe lint all schema files in schema dir instead of only
+  the main schema. #71
+
+### Breaking
+
+- The environment variable to the schema file `LINKML_SCHEMA_SOURCE_PATH` was
+  replaced by a new environment variable `LINKML_SCHEMA_SOURCE_DIR` pointing to
+  the directory with schema files.
 
 ## Release [0.2.2] - 2025-02-17
 

--- a/template/config.public.mk.jinja
+++ b/template/config.public.mk.jinja
@@ -9,7 +9,7 @@
 LINKML_SCHEMA_NAME="{{project_slug}}"
 LINKML_SCHEMA_AUTHOR="{{author}}"
 LINKML_SCHEMA_DESCRIPTION="{{project_description}}"
-LINKML_SCHEMA_SOURCE_PATH="src/{{project_slug}}/schema/{{project_slug}}.yaml"
+LINKML_SCHEMA_SOURCE_DIR="src/{{project_slug}}/schema"
 
 ###### linkml generator variables, used by justfile
 

--- a/template/config.yaml
+++ b/template/config.yaml
@@ -28,9 +28,11 @@ generator_args:
     directory: "docs/elements"
   graphql:
     mergeimports: true
-  java:
-    mergeimports: true
-    metadata: true
+  # gen-java is not yet supported by gen-project.
+  #   https://github.com/linkml/linkml/issues/2537
+  # java:
+  #   mergeimports: true
+  #   metadata: true
   jsonld:
     mergeimports: true
   jsonschema:

--- a/template/justfile
+++ b/template/justfile
@@ -51,12 +51,12 @@ setup: _check-config _git-init install _git-add && _setup_part2
   git commit -m "Initialise git with minimal project" -a
 
 _setup_part2: gen-project gen-doc
-  @echo Various model representations were created under project/. \
-   Firstly, they are ignored by git. You decide if you want to add them to the \
-   tracking via git or git-ignore them as they can be regenerated at any time. \
-   For adding specific files, just add !project/[foldername]/* to your \
-   .gitignore file.
-
+  @echo
+  @echo '=== Setup completed! ==='
+  @echo 'Various model representations have been created under directory "project". By default'
+  @echo 'they are ignored by git. You decide whether you want to add them to git tracking or'
+  @echo 'continue to git-ignore them as they can be regenerated if needed.'
+  @echo 'For tracking specific subfolders, add !project/[foldername]/* line(s) to ".gitignore".'
 
 # Install project dependencies
 [group('project management')]

--- a/template/justfile
+++ b/template/justfile
@@ -19,8 +19,8 @@ shebang := if os() == 'windows' {
 }
 
 # Environment variables with defaults
-schema_name := env_var_or_default("LINKML_SCHEMA_NAME", "")
-source_schema_path := env_var_or_default("LINKML_SCHEMA_SOURCE_PATH", "")
+schema_name := env_var_or_default("LINKML_SCHEMA_NAME", "_no_schema_given_")
+source_schema_dir := env_var_or_default("LINKML_SCHEMA_SOURCE_DIR", "")
 config_yaml := if env_var_or_default("LINKML_GENERATORS_CONFIG_YAML", "") != "" {
   "--config-file " + env_var_or_default("LINKML_GENERATORS_CONFIG_YAML", "")
 } else {
@@ -36,6 +36,7 @@ gen_ts_args := env_var_or_default("LINKML_GENERATORS_TYPESCRIPT_ARGS", "")
 src := "src"
 dest := "project"
 pymodel := src / schema_name / "datamodel"
+source_schema_path := source_schema_dir / schema_name + ".yaml"
 docdir := "docs/elements"  # Directory for generated documentation
 
 # ============== Project recipes ==============
@@ -88,11 +89,12 @@ test: _test-schema _test-python _test-examples
 # Run linting
 [group('model development')]
 lint:
-    poetry run linkml-lint {{source_schema_path}}
+    poetry run linkml-lint {{source_schema_dir}}
 
 # Generate md documentation for the schema
 [group('model development')]
 gen-doc:
+    rm -rf {{docdir}}/*.md
     poetry run gen-doc {{gen_doc_args}} -d {{docdir}} {{source_schema_path}}
 
 # Build docs and run test server
@@ -110,9 +112,7 @@ gen-project:
     poetry run gen-project {{config_yaml}} -d {{dest}} {{source_schema_path}}
     mv {{dest}}/*.py {{pymodel}}
     poetry run gen-pydantic {{gen_pydantic_args}} {{source_schema_path}} > {{pymodel}}/{{schema_name}}_pydantic.py
-    @if [ ! ${{gen_java_args}} ]; then \
-      poetry run gen-java {{gen_java_args}} --output-directory {{dest}}/java/ {{source_schema_path}} || true ; \
-    fi
+    poetry run gen-java {{gen_java_args}} --output-directory {{dest}}/java/ {{source_schema_path}}
     @if [ ! ${{gen_owl_args}} ]; then \
       mkdir -p {{dest}}/owl && \
       poetry run gen-owl {{gen_owl_args}} {{source_schema_path}} > {{dest}}/owl/{{schema_name}}.owl.ttl || true ; \
@@ -233,8 +233,9 @@ _clean_project:
         else:
             d.unlink()
 
-_ensure_examples_output:
+_ensure_examples_output:  # Ensure a clean examples/output directory exists
     -mkdir -p examples/output
+    -rm -rf examples/output/*.*
 
 # ============== Include project-specific recipes ==============
 

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -45,7 +45,14 @@ mknotebooks = ">= 0.8.0"
 
 # Ref.: https://github.com/codespell-project/codespell
 [tool.codespell]
-skip = "LICENSE,poetry.lock,pyproject.toml"
+skip = [
+  "LICENSE",
+  "pyproject.toml",
+  "poetry.lock",
+  "project/*",
+  "src/{{project_slug}}/datamodel/{{project_slug}}_pydantic.py",
+  "src/{{project_slug}}/datamodel/{{project_slug}}.py",
+]
 
 # Reminder: words have to be lowercased for the ignore-words-list
 ignore-words-list = "linke"
@@ -59,4 +66,7 @@ extend-exclude = [
   "LICENSE",
   "poetry.lock",
   "pyproject.toml",
+  "project/*",
+  "src/{{project_slug}}/datamodel/{{project_slug}}_pydantic.py",
+  "src/{{project_slug}}/datamodel/{{project_slug}}.py",
 ]


### PR DESCRIPTION
This fixes / changes some just recipes to
- build the java model (gen-project does not build it)
- clean up dirs before recreating content
- change lint recipe to lint all schema files not just the main schema
- replace the environment variable `LINKML_SCHEMA_SOURCE_PATH` by a new environment variable `LINKML_SCHEMA_SOURCE_DIR` that points to the directory with schema files.
- update CHANGELOG for next release 0.3.0

Closes #71 
Closes #70 
Closes #66