### PR TITLE
Fix docs preview action permissions

### DIFF
--- a/template/.github/workflows/{% if gh_action_docs_preview %}test_pages_build.yaml{% endif %}.jinja
+++ b/template/.github/workflows/{% if gh_action_docs_preview %}test_pages_build.yaml{% endif %}.jinja
@@ -13,13 +13,17 @@ permissions: {}
 
 jobs:
   run:
+    # Grant GITHUB_TOKEN the permissions required to make a gh-pages deployment
+    permissions:
+      contents: write  # to let mkdocs write the new docs
+      pages: write     # to deploy to Pages
+      id-token: write  # allow to generate an OpenID Connect (OIDC) token
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Set up Python 3
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -43,6 +43,10 @@ mkdocs-mermaid2-plugin = ">=1.1.1"
 jupyter = ">=1.0.0"
 mknotebooks = ">= 0.8.0"
 
+# Ref.: https://docs.pytest.org/en/stable/reference/reference.html#configuration-options
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 # Ref.: https://github.com/codespell-project/codespell
 [tool.codespell]
 skip = [


### PR DESCRIPTION
The docs-preview action also needs the permission to post a message to the PR. Also we can't delete credentials after checkout because we need them later.

@StroemPhi - This grants just the extra permission required. You will get it with the next template update. I verified the change in https://github.com/dalito/test-linkml-project-copier/pull/5

Closes #73