### PR TITLE
justfile recipe improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 [Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.3.0...main)
 
+### Added
+
+- The `just gen-doc` command will now also build a merged schema (yaml).
+- The `just test` command will now also test all json test datafiles (in addition to yaml).
+
+### Fixed
+
+- Give docs-preview permission to publish messages in PR thread. #74
+
 ## Release [0.3.0] - 2025-03-02
 
 [Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.2.2...0.3.0)

--- a/template/justfile
+++ b/template/justfile
@@ -38,6 +38,7 @@ dest := "project"
 pymodel := src / schema_name / "datamodel"
 source_schema_path := source_schema_dir / schema_name + ".yaml"
 docdir := "docs/elements"  # Directory for generated documentation
+merged_schema_path := "docs/schema" / schema_name + ".yaml"
 
 # ============== Project recipes ==============
 
@@ -93,8 +94,7 @@ lint:
 
 # Generate md documentation for the schema
 [group('model development')]
-gen-doc:
-    rm -rf {{docdir}}/*.md
+gen-doc: _gen-yaml
     poetry run gen-doc {{gen_doc_args}} -d {{docdir}} {{source_schema_path}}
 
 # Build docs and run test server
@@ -188,12 +188,18 @@ _test-python: gen-python
 # Run example tests
 _test-examples: _ensure_examples_output
     poetry run linkml-run-examples \
+        --input-formats json \
+        --input-formats yaml \
         --output-formats json \
         --output-formats yaml \
         --counter-example-input-directory tests/data/invalid \
         --input-directory tests/data/valid \
         --output-directory examples/output \
         --schema {{source_schema_path}} > examples/output/README.md
+
+# Generate merged model
+_gen-yaml:
+  poetry run gen-yaml {{source_schema_path}} > {{merged_schema_path}}
 
 # Run documentation server
 _serve:


### PR DESCRIPTION
- The `just gen-doc` command will now also build a merged schema (yaml).
- The `just test` command will now also test all json test datafiles (in addition to yaml).
