### PR TITLE
Update dependencies and fix min Python version in template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: "/"
+    directories:
+      - "/"
+      # Note that dependabot can't update actions in the jinja2 action templates
+      - "/template"
     schedule:
       interval: monthly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,25 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 [Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.3.0...main)
 
+## Release [0.3.1] - 2025-04-04
+
+[Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.3.0...0.3.1)
+
+[0.3.1]: https://github.com/dalito/linkml-project-copier/releases/tag/v0.3.1
+
 ### Added
 
 - The `just gen-doc` command will now also build a merged schema (yaml).
-- The `just test` command will now also test all json test datafiles (in addition to yaml).
+- The `just test` command will now also test all json test datafiles (in addition to yaml). #79
 
 ### Fixed
 
-- Give docs-preview permission to publish messages in PR thread. #74
+- Give docs-preview required permission to publish messages in PR thread. #74
+- Correct lower Python boundary to 3.9 in template. #80
+
+### Changed
+
+- Applied April-2025 updates to dependencies of gh-actions. #80
 
 ## Release [0.3.0] - 2025-03-02
 

--- a/template/.github/workflows/{% if gh_action_docs_preview %}test_pages_build.yaml{% endif %}.jinja
+++ b/template/.github/workflows/{% if gh_action_docs_preview %}test_pages_build.yaml{% endif %}.jinja
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python 3
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
           python-version: 3.9
 

--- a/template/.github/workflows/{% if gh_action_pypi %}pypi-publish.yaml{% endif %}.jinja
+++ b/template/.github/workflows/{% if gh_action_pypi %}pypi-publish.yaml{% endif %}.jinja
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
           python-version: 3.9
 
@@ -49,7 +49,7 @@ jobs:
         run: poetry build
 
       - name: Store built distribution
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: distribution-files
           path: dist/
@@ -60,12 +60,12 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi-release
-      url: https://pypi.org/p/{{ project_slug }}
+      url: https://pypi.org/p/test_linkml_project_copier
     permissions:
       id-token: write  # this permission is mandatory for trusted publishing
     steps:
       - name: Download built distribution
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
         with:
           name: distribution-files
           path: dist

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -14,7 +14,7 @@ readme = "README.md"
 include = ["README.md", "src/{{project_slug}}/schema", "project"]
 
 # We can't use caret ^ requirement specifiers here. They are a Poetry speciality.
-requires-python = ">=3.11,<4.0"
+requires-python = ">=3.9,<4.0"
 
 dynamic = ["version"]
 


### PR DESCRIPTION
- Set lower Python boundary to 3.9 in template.
- Applied April-2025 updates to dependencies of gh-actions.
