### PR TITLE
Migrate templated project from poetry to uv

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -6,6 +6,9 @@ on:  # yamllint disable-line rule:truthy
   pull_request:
     branches: [main]
 
+env:
+  CLICOLOR: 1
+
 permissions: {}
 
 jobs:

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -2,8 +2,6 @@
 
 extends: default
 
-locale: en_US.UTF-8  # Set the locale to avoid issues on Windows.
-
 rules:
   document-start: disable  # Don't check if document has a start marker (---).
   line-length:

--- a/README.md
+++ b/README.md
@@ -36,48 +36,22 @@ We assume that you have full internet access.
 
   LinkML tools are mainly written in Python, so you will need a recent Python interpreter to run this generator and to use the generated project.
 
-* **pipx**
+* **uv**
 
-  pipx is a tool for managing isolated Python-based applications. It is the recommended way to install the required tools.
-  To install pipx follow their [instructions](https://pypa.github.io/pipx/installation/).
-
-* **Poetry**
-
-  Poetry is a Python project management tool.
+  uv is a tool to manage Python projects and for managing isolated Python-based applications.
   You will use it in your generated project to manage dependencies and build distribution files.
-  Install Poetry by running:
-
-  ```shell
-  pipx install poetry
-  ```
-
-  This will install Poetry 2.x as required by this project.
-  If you also need Poetry 1.x for other projects, you can have both Poetry 2.x and Poetry 1.x installed at the same time.
-  pipx has the option to install another version with a suffix-modified name, here "poetry1",
-
-  ```shell
-  pipx install --suffix=1 "poetry<2.0"
-  ```
-
-* **Poetry Dynamic Versioning Plugin**:
-
-  This plugin automatically updates certain version strings in your generated project when you publish it.
-  Install it by running:
-
-  ```shell
-  pipx inject poetry "poetry-dynamic-versioning[plugin]"
-  ```
+  Install uv by following their [instructions](https://docs.astral.sh/uv/getting-started/installation/)
 
 * **copier**
 
   Copier is a tool for generating projects based on a template (like this one!).
   It also allows re-configuring the projects and to keep them updated when the original template changes.
   To insert dates into the template, copier requires [jinja2_time](https://github.com/hackebrot/jinja2-time) in the copier environment.
-  Install both with pipx by running:
+  Install both with `uv tool` by running:
 
   ```shell
-  pipx install copier
-  pipx inject copier jinja2_time
+  uv tool install copier
+  uv tool inject copier jinja2_time
   ```
 
 * **just**
@@ -86,7 +60,7 @@ We assume that you have full internet access.
   To execute these commands you need [just](https://github.com/casey/just) as command runner. Install it by running:
 
   ```shell
-  pipx install rust-just
+  uv tool install rust-just
   ```
 
 ## Creating a new project
@@ -136,7 +110,7 @@ Included are [yamllint](https://github.com/adrienverge/yamllint) for consistent 
 [ruff](https://docs.astral.sh/ruff/) for formatting and linting Python code and
 the spell checkers [codespell](https://github.com/codespell-project/codespell) and [typos](https://github.com/crate-ci/typos). To use this
 
-* install pre-commit with: `pipx install pre-commit`
+* install pre-commit with: `uv tool install pre-commit`
 * activate pre-commit in the project by running (at the root of the project): `pre-commit install`
 
 Once installed pre-commit will perform the checks on every commit and reject a commit if errors are found;

--- a/template/.github/workflows/deploy-docs.yaml
+++ b/template/.github/workflows/deploy-docs.yaml
@@ -30,25 +30,26 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email github-actions[bot]@users.noreply.github.com
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
+        with:
+          python-version: 3.12
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
       - name: Set up Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
           python-version: 3.12
 
-      - name: Install poetry incl. plugins and just
-        # We install poetry-dynamic-versioning into pipx because the automatic
-        # install by poetry 2.x triggers a Windows issue
-        # https://github.com/pypa/installer/issues/260
-        # and also does not work on Ubuntu in gh-actions.
+      - name: Install just
         run: |
-          pipx install poetry
-          pipx inject poetry poetry-dynamic-versioning
-          pipx install rust-just
+          uv tool install rust-just
 
       - name: Install dependencies
-        run: poetry install
+        run: uv sync --dev --no-progress
 
-      - name: Build and deploy documentation
+      - name: Generate schema documentation
         run: |
           just gen-doc
-          poetry run mkdocs gh-deploy
+          uv run mkdocs gh-deploy

--- a/template/.github/workflows/main.yaml
+++ b/template/.github/workflows/main.yaml
@@ -8,6 +8,9 @@ on:  # yamllint disable-line rule:truthy
     branches: [main]
   pull_request:
 
+env:
+  FORCE_COLOR: "1" # Make tools pretty.
+
 permissions: {}
 
 jobs:
@@ -17,6 +20,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
+      fail-fast: false
 
     steps:
 
@@ -25,26 +29,24 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install just & Poetry incl. plugins
-        # We install poetry-dynamic-versioning into pipx because the automatic
-        # install by poetry 2.x triggers a Windows issue
-        # https://github.com/pypa/installer/issues/260
-        # and also does not work on Ubuntu in gh-actions.
+      - name: Install just
         run: |
-          pipx install rust-just
-          pipx install poetry
-          pipx inject poetry poetry-dynamic-versioning
-
-      - name: Install dependencies
-        run: poetry install --no-interaction --no-root
+          uv tool install rust-just
 
       - name: Install project
-        run: poetry install --no-interaction
+        run: uv sync --dev
 
       - name: Run test suite
         run: just test

--- a/template/.github/workflows/{% if gh_action_docs_preview %}test_pages_build.yaml{% endif %}.jinja
+++ b/template/.github/workflows/{% if gh_action_docs_preview %}test_pages_build.yaml{% endif %}.jinja
@@ -22,6 +22,7 @@ jobs:
       contents: write  # to let mkdocs write the new docs
       pages: write     # to deploy to Pages
       id-token: write  # allow to generate an OpenID Connect (OIDC) token
+      pull-requests: write  # add comment on the PR with the preview URL
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/template/.github/workflows/{% if gh_action_docs_preview %}test_pages_build.yaml{% endif %}.jinja
+++ b/template/.github/workflows/{% if gh_action_docs_preview %}test_pages_build.yaml{% endif %}.jinja
@@ -7,6 +7,10 @@ on:  # yamllint disable-line rule:truthy
       - reopened
       - synchronize
 
+
+env:
+  CLICOLOR: 1
+
 concurrency: {% raw %}preview-${{ github.ref }}{% endraw %}
 
 permissions: {}
@@ -25,26 +29,24 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
+        with:
+          python-version: 3.12
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
       - name: Set up Python 3
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
-          python-version: 3.9
-
-      - name: Install poetry incl. plugins
-        # We install poetry-dynamic-versioning into pipx because the automatic
-        # install by poetry 2.x triggers a Windows issue
-        # https://github.com/pypa/installer/issues/260
-        # and also does not work on Ubuntu in gh-actions.
-        run: |
-          pipx install poetry
-          pipx inject poetry poetry-dynamic-versioning
+          python-version: 3.12
 
       - name: Install dependencies
-        run: poetry install
+        run: uv sync --dev --no-progress
 
       - name: Build documentation
         run: |
-          poetry run mkdocs build -d site
+          uv run mkdocs build -d site
           touch site/.nojekyll
 
       - name: Deploy preview

--- a/template/.github/workflows/{% if gh_action_pypi %}pypi-publish.yaml{% endif %}.jinja
+++ b/template/.github/workflows/{% if gh_action_pypi %}pypi-publish.yaml{% endif %}.jinja
@@ -14,6 +14,7 @@ on:  # yamllint disable-line rule:truthy
       # GitHub glob matching is limited [1]. So we can't define a pattern matching
       # pep 440 version definition [N!]N(.N)*[{a|b|rc}N][.postN][.devN]
       - 'v[0-9]+.[0-9]+.[0-9]+.?*'
+      - 'v[0-9]+.[0-9]+.[0-9]+rc[0-9]'
   release:
     types: [published]
 
@@ -30,23 +31,23 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
+        with:
+          python-version: 3.12
+          enable-cache: true
+
       - name: Set up Python
         uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
         with:
-          python-version: 3.9
+          python-version: 3.12
 
-      - name: Install just & poetry incl. plugins
-        # We install poetry-dynamic-versioning into pipx because the automatic
-        # install by poetry 2.x triggers a Windows issue
-        # https://github.com/pypa/installer/issues/260
-        # and also does not work on Ubuntu in gh-actions.
+      - name: Install just
         run: |
-          pipx install rust-just
-          pipx install poetry
-          pipx inject poetry poetry-dynamic-versioning
+          uv tool install rust-just
 
       - name: Build source and wheel archives
-        run: poetry build
+        run: uv build
 
       - name: Store built distribution
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -60,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi-release
-      url: https://pypi.org/p/test_linkml_project_copier
+      url: https://pypi.org/p/{{project_slug}}
     permissions:
       id-token: write  # this permission is mandatory for trusted publishing
     steps:
@@ -86,6 +87,7 @@ jobs:
 # [1] https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
 # Used actions: (updates managed by dependabot)
 # - https://github.com/actions/checkout
+# - https://github.com/astral-sh/setup-uv
 # - https://github.com/actions/setup-python
 # - https://github.com/actions/upload-artifact
 # - https://github.com/actions/download-artifact

--- a/template/.pre-commit-config.yaml
+++ b/template/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.35.1
+    rev: v1.37.0
     hooks:
       - id: yamllint
         args: [-c=.yamllint.yaml]
@@ -24,16 +24,22 @@ repos:
           - tomli
 
   - repo: https://github.com/crate-ci/typos
-    rev: v1.29.7
+    rev: v1.31.1
     hooks:
       - id: typos
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.6
+    rev: v0.11.3
     hooks:
       # Run the linter.
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       # Run the formatter.
       - id: ruff-format
+
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version.
+    rev: 0.6.12
+    hooks:
+      - id: uv-lock

--- a/template/.yamllint.yaml
+++ b/template/.yamllint.yaml
@@ -2,11 +2,6 @@
 
 extends: default
 
-ignore:
-  # Ignore file with unicode chars to avoid Windows failure due a yamllint bug
-  # Remove after PR https://github.com/adrienverge/yamllint/pull/696 is merged
-  - /.github/workflows/pypi-publish.yaml
-
 rules:
   document-start: disable  # Don't check if document has a start marker (---).
   line-length:

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
-build-backend = "poetry_dynamic_versioning.backend"
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
 
 [project]
 name = "{{project_slug}}"
@@ -11,37 +11,33 @@ authors = [
 license = "{{license}}"
 license-files = ["LICENSE"]
 readme = "README.md"
-include = ["README.md", "src/{{project_slug}}/schema", "project"]
-
-# We can't use caret ^ requirement specifiers here. They are a Poetry speciality.
 requires-python = ">=3.9,<4.0"
-
 dynamic = ["version"]
 
 dependencies = [
   "linkml-runtime >=1.8.0",
 ]
 
-# Ref.: https://python-poetry.org/docs/
-# Ref.: https://github.com/mtkennerly/poetry-dynamic-versioning
-[tool.poetry]
-requires-poetry = ">=2.0"
-version = "0.0.0"
+[dependency-groups]
+dev = [
+    "linkml>=1.3.5",
+    "mkdocs-material>=8.2.8",
+    "mkdocs-mermaid2-plugin>=1.1.1",
+    "jupyter>=1.0.0",
+    "mknotebooks>= 0.8.0",
+]
 
-[tool.poetry.requires-plugins]
-poetry-dynamic-versioning = ">=1.7.0"
+# See https://hatch.pypa.io/latest/config/build/#file-selection for how to
+# explicitly include files other than default into the build distributions.
 
-[tool.poetry-dynamic-versioning]
-enable = true
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+# Ref.: https://github.com/ninoseki/uv-dynamic-versioning/
+[tool.uv-dynamic-versioning]
 vcs = "git"
 style = "pep440"
-
-[tool.poetry.group.dev.dependencies]
-linkml = ">=1.3.5"
-mkdocs-material = ">=8.2.8"
-mkdocs-mermaid2-plugin = ">=1.1.1"
-jupyter = ">=1.0.0"
-mknotebooks = ">= 0.8.0"
+fallback-version = "0.0.0"
 
 # Ref.: https://docs.pytest.org/en/stable/reference/reference.html#configuration-options
 [tool.pytest.ini_options]
@@ -52,7 +48,7 @@ testpaths = ["tests"]
 skip = [
   "LICENSE",
   "pyproject.toml",
-  "poetry.lock",
+  "uv.lock",
   "project/*",
   "src/{{project_slug}}/datamodel/{{project_slug}}_pydantic.py",
   "src/{{project_slug}}/datamodel/{{project_slug}}.py",
@@ -68,7 +64,7 @@ linke = "linke"
 [tool.typos.files]
 extend-exclude = [
   "LICENSE",
-  "poetry.lock",
+  "uv.lock",
   "pyproject.toml",
   "project/*",
   "src/{{project_slug}}/datamodel/{{project_slug}}_pydantic.py",

--- a/template/src/{{project_slug}}/_version.py
+++ b/template/src/{{project_slug}}/_version.py
@@ -4,6 +4,5 @@ try:
     __version__ = version(__name__)
 except PackageNotFoundError:
     # package not installed
-    # poetry-dynamic-versioning will insert here the correct version on build
     __version__ = "0.0.0"
     __version_tuple__ = (0, 0, 0)


### PR DESCRIPTION
Migration from poetry 2.x and poetry-dynamic-versioning to

- [uv](https://docs.astral.sh/uv/) package manager. We also use `uv tool` instead of `pipx` to reduce the number of required tools.
- [uv-dynamic-versioning](https://github.com/ninoseki/uv-dynamic-versioning) dynamic versioning add-on
- [hatch](https://hatch.pypa.io/latest/) build tool.

Other changes:
- Fix permission in docs-preview action (`test_pages_build.yaml`).

Closes #45