### PR TITLE
Create docs/schema directory if not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 ### Fixed
 
 - Adjust docs-preview required permission to publish messages in PR thread.
+- Create directory `docs/schema` within `_gen-yaml` recipe if not present.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 ### Added
 
 - New pre-commit command that updates the uv.lock file. #81
+- Automatic publishing of releases to Zenodo ([doi:10.5281/zenodo.15163584](https://doi.org/10.5281/zenodo.15163584)). #
 
 ### Fixed
 

--- a/template/justfile
+++ b/template/justfile
@@ -199,6 +199,7 @@ _test-examples: _ensure_examples_output
 
 # Generate merged model
 _gen-yaml:
+  -mkdir -p docs/schema
   uv run gen-yaml {{source_schema_path}} > {{merged_schema_path}}
 
 # Run documentation server


### PR DESCRIPTION
For a fresh project `just setup` failed in `_gen-yaml` because of the initially missing dir `docs/schema`. This directory is now created in the recipe if not present.