### PR TITLE
Update action versions and change from hash to text version

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -19,10 +19,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
       - name: Run codespell on Repo
-        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630
+        uses: codespell-project/actions-codespell@v2.1
         with:
           skip: '*.js'

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -17,9 +17,9 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 
       - name: Run typos on repo
-        uses: crate-ci/typos@3be83342e28b9421997e9f781f713f8dde8453d2
+        uses: crate-ci/typos@v1.31.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 [Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.4.0...main)
 
+### Changed
+
+- Update github actions in project and change from hash version specifier to text. #86
+
 ## Release [0.4.0] - 2025-04-06
 
 [Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.3.1...0.4.0)

--- a/template/.github/dependabot.yml
+++ b/template/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference
 
 version: 2
 updates:

--- a/template/.github/workflows/deploy-docs.yaml
+++ b/template/.github/workflows/deploy-docs.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0  # otherwise, you will fail to push refs to dest repo
 
@@ -31,14 +31,14 @@ jobs:
           git config user.email github-actions[bot]@users.noreply.github.com
 
       - name: Install uv
-        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
+        uses: astral-sh/setup-uv@v6.0.1
         with:
           python-version: 3.12
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: Set up Python
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: 3.12
 

--- a/template/.github/workflows/main.yaml
+++ b/template/.github/workflows/main.yaml
@@ -25,19 +25,19 @@ jobs:
     steps:
 
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
+        uses: astral-sh/setup-uv@v6.0.1
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/template/.github/workflows/{% if gh_action_docs_preview %}test_pages_build.yaml{% endif %}.jinja
+++ b/template/.github/workflows/{% if gh_action_docs_preview %}test_pages_build.yaml{% endif %}.jinja
@@ -7,7 +7,6 @@ on:  # yamllint disable-line rule:truthy
       - reopened
       - synchronize
 
-
 env:
   CLICOLOR: 1
 
@@ -26,19 +25,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
+        uses: astral-sh/setup-uv@v6.0.1
         with:
           python-version: 3.12
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: Set up Python 3
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: 3.12
 
@@ -51,7 +50,7 @@ jobs:
           touch site/.nojekyll
 
       - name: Deploy preview
-        uses: rossjrw/pr-preview-action@df22037db54ab6ee34d3c1e2b8810ac040a530c6
+        uses: rossjrw/pr-preview-action@v1.6.1
         with:
           source-dir: site/
           preview-branch: gh-pages

--- a/template/.github/workflows/{% if gh_action_pypi %}pypi-publish.yaml{% endif %}.jinja
+++ b/template/.github/workflows/{% if gh_action_pypi %}pypi-publish.yaml{% endif %}.jinja
@@ -27,18 +27,18 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@v4.2.2
         with:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
+        uses: astral-sh/setup-uv@v6.0.1
         with:
           python-version: 3.12
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+        uses: actions/setup-python@v5.6.0
         with:
           python-version: 3.12
 
@@ -50,7 +50,7 @@ jobs:
         run: uv build
 
       - name: Store built distribution
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: distribution-files
           path: dist/
@@ -66,21 +66,21 @@ jobs:
       id-token: write  # this permission is mandatory for trusted publishing
     steps:
       - name: Download built distribution
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e
+        uses: actions/download-artifact@v4.3.0
         with:
           name: distribution-files
           path: dist
 
       - name: Publish package 📦 to Test PyPI
         if: github.event_name == 'push'
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        uses: pypa/gh-action-pypi-publish@v1.12
         with:
           repository-url: https://test.pypi.org/legacy/
           verbose: true
 
       - name: Publish package 📦 to PyPI
         if: github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+        uses: pypa/gh-action-pypi-publish@v1.12
         with:
           verbose: true
 


### PR DESCRIPTION
For most users of the template working with hash-specified action versions is quite inconvenient. So this PR switches to text version specifiers.