### PR TITLE
Fix uv install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 [Full changelog](https://github.com/dalito/linkml-project-copier/compare/v0.4.1...main)
 
-(nothing yet)
+### Fixed
+
+- Fix `uv tool` command that includes jinja2-time into copier. #90
 
 ## Release [0.4.1] - 2025-08-02
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,11 @@ We assume that you have full internet access.
 
   Copier is a tool for generating projects based on a template (like this one!).
   It also allows re-configuring the projects and to keep them updated when the original template changes.
-  To insert dates into the template, copier requires [jinja2_time](https://github.com/hackebrot/jinja2-time) in the copier environment.
+  To insert dates into the template, copier requires [jinja2-time](https://github.com/hackebrot/jinja2-time) in the copier environment.
   Install both with `uv tool` by running:
 
   ```shell
-  uv tool install copier
-  uv tool inject copier jinja2_time
+  uv tool install --with jinja2-time copier
   ```
 
 * **just**


### PR DESCRIPTION
"inject" was a pipx feature. `uv tool` requires a different command to install jinja2-time into copier.